### PR TITLE
Fixed required rules

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -2,6 +2,7 @@
 
 namespace MadeSimple\Validator;
 
+use Countable;
 use MadeSimple\Arrays\ArrDots;
 
 // Add polyfill in case where running in < PHP 7.3
@@ -99,7 +100,12 @@ class Validate
 
         // Check value is not null
         foreach (Validator::getValues($data, $pattern) as $attribute => $value) {
-            if (!empty($value)) {
+            // not allowed: null, '', [], empty instance Countable
+            if (!(
+                (is_null($value)) ||
+                (is_string($value) && $value === '') ||
+                ((is_array($value) || is_a($value, Countable::class)) && empty($value))
+            )) {
                 continue;
             }
 

--- a/src/Validate.php
+++ b/src/Validate.php
@@ -67,6 +67,22 @@ class Validate
 
 
     /**
+     * Checks whether or not $value is filled, 
+     * i.e. $value is no empty string, array or Countable and not null.
+     * 
+     * @param mixed $value
+     * 
+     * @return bool true when $value is filled, elsewise false
+     */
+    protected static function isFilled($value) {
+        return !(
+            (is_null($value)) ||
+            (is_string($value) && $value === '') ||
+            ((is_array($value) || is_a($value, Countable::class)) && empty($value))
+        );
+    }
+    
+    /**
      * present
      *
      * @param \MadeSimple\Validator\Validator $validator
@@ -101,11 +117,7 @@ class Validate
         // Check value is not null
         foreach (Validator::getValues($data, $pattern) as $attribute => $value) {
             // not allowed: null, '', [], empty instance Countable
-            if (!(
-                (is_null($value)) ||
-                (is_string($value) && $value === '') ||
-                ((is_array($value) || is_a($value, Countable::class)) && empty($value))
-            )) {
+            if (static::isFilled($value)) {
                 continue;
             }
 
@@ -147,11 +159,11 @@ class Validate
             $fieldAttribute = $isWild ? Str::overlapLeftMerge($overlap, $attribute, $field) : $field;
             $fieldValue     = ArrDots::get($data, $fieldAttribute);
 
-            if ($fieldValue === null || !in_array($fieldValue, $values)) {
+            if (!static::isFilled($fieldValue) || !in_array($fieldValue, $values)) {
                 continue;
             }
 
-            if (null !== $value) {
+            if (static::isFilled($value)) {
                 continue;
             }
 
@@ -189,10 +201,10 @@ class Validate
             $fieldAttribute = $isWild ? Str::overlapLeftMerge($overlap, $attribute, $field) : $field;
             $fieldValue     = ArrDots::get($data, $fieldAttribute);
 
-            if ($fieldValue === null) {
+            if (!static::isFilled($fieldValue)) {
                 continue;
             }
-            if ($fieldValue !== null && $value !== null) {
+            if (static::isFilled($value)) {
                 continue;
             }
 
@@ -233,7 +245,7 @@ class Validate
                 foreach ($parameters as $k => $field) {
                     $fieldAttribute = $overlaps[$k] ? Str::overlapLeftMerge($overlaps[$k], $attribute, $field) : $field;
                     $fieldValue     = ArrDots::get($data, $fieldAttribute);
-                    $required       = $required && $fieldValue !== null;
+                    $required       = $required && static::isFilled($fieldValue);
                     if (!$required) {
                         break;
                     }
@@ -258,7 +270,7 @@ class Validate
             foreach ($parameters as $k => $field) {
                 $fieldAttribute = $overlaps[$k] ? Str::overlapLeftMerge($overlaps[$k], $attribute, $field) : $field;
                 $fieldValue     = ArrDots::get($data, $fieldAttribute);
-                $required       = $required && $fieldValue !== null;
+                $required       = $required && static::isFilled($fieldValue);
                 if (!$required) {
                     break;
                 }
@@ -301,7 +313,7 @@ class Validate
             $required = array_reduce($parameters, function ($required, $field) use ($validator, $data) {
                 if (!$required && ArrDots::has($data, $field, $validator::WILD)) {
                     foreach (Validator::getValues($data, $field) as $value) {
-                        $required = $required || $value !== null;
+                        $required = $required || static::isFilled($value);
                     }
 
                 }
@@ -323,7 +335,7 @@ class Validate
             foreach ($parameters as $k => $field) {
                 $fieldAttribute = $overlaps[$k] ? Str::overlapLeftMerge($overlaps[$k], $attribute, $field) : $field;
                 $fieldValue     = ArrDots::get($data, $fieldAttribute);
-                $required       = $required || $fieldValue !== null;
+                $required       = $required || static::isFilled($fieldValue);
                 if ($required) {
                     break;
                 }
@@ -363,13 +375,13 @@ class Validate
 
         // Check value is not null
         foreach (Validator::getValues($data, $pattern) as $attribute => $value) {
-            if ($value !== null) {
+            if (static::isFilled($value)) {
                 continue;
             }
 
             $fieldAttribute = $isWild ? Str::overlapLeftMerge($overlap, $attribute, $field) : $field;
             $fieldValue     = ArrDots::get($data, $fieldAttribute);
-            if ($fieldValue !== null) {
+            if (static::isFilled($fieldValue)) {
                 continue;
             }
 

--- a/tests/Integration/ValidateRequiredTest.php
+++ b/tests/Integration/ValidateRequiredTest.php
@@ -39,6 +39,17 @@ class ValidateRequiredTest extends TestCase
         $this->assertEquals($errors, $this->validator->getProcessedErrors());
     }
 
+    public function testValidateRequiredInvalidEmpty()
+    {
+        $rules  = ['roles' => 'required'];
+        $values = ['roles' => []];
+        $errors = ['errors' => ['roles' => ['required' => 'Roles is required']]];
+        $this->validator->validate($values, $rules);
+
+        $this->assertTrue($this->validator->hasErrors());
+        $this->assertEquals($errors, $this->validator->getProcessedErrors());
+    }
+
     public function testValidateRequiredValidDots()
     {
         $rules  = ['user.*.name' => 'required'];
@@ -64,6 +75,17 @@ class ValidateRequiredTest extends TestCase
         $rules  = ['user.*.name' => 'required'];
         $values = ['user' => [['name' => null]]];
         $errors = ['errors' => ['user.0.name' => ['required' => 'User 0 name is required']]];
+        $this->validator->validate($values, $rules);
+
+        $this->assertTrue($this->validator->hasErrors());
+        $this->assertEquals($errors, $this->validator->getProcessedErrors());
+    }
+    
+    public function testValidateRequiredInvalidEmptyDots()
+    {
+        $rules  = ['user.*.roles' => 'required'];
+        $values = ['user' => [['roles' => []]]];
+        $errors = ['errors' => ['user.0.roles' => ['required' => 'User 0 roles is required']]];
         $this->validator->validate($values, $rules);
 
         $this->assertTrue($this->validator->hasErrors());


### PR DESCRIPTION
The former implementation of the Required rule validated '0' to be invalid. But as transferred query and post data always comes as strings, this would be unexpected behaviour.
The rule now checks for null and empty strings, arrays and Countable instances.
Integration test for Required rule has also been extended.
Any other required-* rule has also been fixed.
